### PR TITLE
Add caps for cursor position report

### DIFF
--- a/info/yaft.cap
+++ b/info/yaft.cap
@@ -17,4 +17,5 @@ yaft-256color|yet another framebuffer terminal:\
 	:mb=\E[5m:md=\E[1m:me=\E[m:mr=\E[7m:nd=\E[C:nw=\EE:\
 	:op=\E[39;49m:rc=\E8:rs=\Ec:sc=\E7:se=\E[27m:sf=^J:\
 	:so=\E[7m:sr=\EM:st=\EH:ta=^I:ue=\E[24m:up=\E[A:us=\E[4m:\
-	:ve=\E[?25h:vi=\E[?25l:
+	:ve=\E[?25h:vi=\E[?25l:\
+	:u6=\E[%d;%dR:u7=\E[6n:

--- a/info/yaft.src
+++ b/info/yaft.src
@@ -58,3 +58,5 @@ yaft-256color|yet another framebuffer terminal,
 	kb2=\E[G, kbs=\177, kcbt=\E[Z,
 	khome=\E[1~, kich1=\E[2~, kdch1=\E[3~, kend=\E[4~,
 	kmous=\E[M, knp=\E[6~, kpp=\E[5~, kspd=^Z,
+
+	u6=\E[%i%d;%dR, u7=\E[6n,


### PR DESCRIPTION
According to terminfo.src at ncurses, u6/u7 represent cursor position report/request sequences.

>   u7  cursor position request (equiv. to VT100/ANSI/ECMA-48 DSR 6)
>   u6  cursor position report (equiv. to ANSI/ECMA-48 CPR)
