### PR TITLE
Use FRAMEBUFFER enviroment variable if specified

### DIFF
--- a/conf.h
+++ b/conf.h
@@ -24,15 +24,17 @@ const char *term_name = "yaft-256color";
 
 /* framubuffer device */
 #if defined(__linux__)
-	const char *fb_path = "/dev/fb0";
+	const char *fb_path_default = "/dev/fb0";
 #elif defined(__FreeBSD__)
-	const char *fb_path = "/dev/tty";
+	const char *fb_path_default = "/dev/tty";
 #elif defined(__NetBSD__)
-	const char *fb_path = "/dev/ttyE0";
+	const char *fb_path_default = "/dev/ttyE0";
 #elif defined(__OpenBSD__)
-	const char *fb_path = "/dev/ttyC0";
+	const char *fb_path_default = "/dev/ttyC0";
 #endif
-//const char *fb_path = "/dev/graphics/fb0"; /* for Android */
+//const char *fb_path_default = "/dev/graphics/fb0"; /* for Android */
+
+extern const char *fb_path;
 
 /* shell: refer SHELL environment at first */
 #if defined(__linux__) || defined(__MACH__)

--- a/yaft.c
+++ b/yaft.c
@@ -13,6 +13,8 @@
 	#include "fb/openbsd.h"
 #endif
 
+const char *fb_path;
+
 #include "draw.h"
 #include "terminal.h"
 #include "function.h"
@@ -147,6 +149,8 @@ int main()
 	struct termios save_tm;
 
 	/* init */
+	if ((fb_path = getenv("FRAMEBUFFER")) != NULL)
+		fb_path = fb_path_default;
 	setlocale(LC_ALL, "");
 	fb_init(&fb, term.color_palette);
 	term_init(&term, fb.width, fb.height);


### PR DESCRIPTION
FRAMEBUFFER環境変数が指定されている場合、その値をフレームバッファ・デバイスのパスとして利用するようにしました。未指定の場合はconfig.hの設定に従います。（fbvと同様の仕様）