### PR TITLE
improving responsiveness under heavy scrolling

### DIFF
--- a/ctrlseq/dcs.h
+++ b/ctrlseq/dcs.h
@@ -361,7 +361,7 @@ void sixel_copy2cell(struct terminal_t *term, struct sixel_canvas_t *sc)
 	for (y = 0; y < lines; y++) {
 		for (x = 0; x < cols; x++) {
 			erase_cell(term, term->cursor.y, term->cursor.x + x);
-			cellp = &term->cells[term->cursor.y * term->cols + (term->cursor.x + x)];
+			cellp = &term->cells[term->cursor.y][term->cursor.x + x];
 			cellp->has_pixmap = true;
 			for (h = 0; h < CELL_HEIGHT; h++) {
 				src_offset = (y * CELL_HEIGHT + h) * sc->line_length + (CELL_WIDTH * x) * BYTES_PER_PIXEL;

--- a/fb/common.h
+++ b/fb/common.h
@@ -394,7 +394,7 @@ static inline void draw_line(struct framebuffer_t *fb, struct terminal_t *term, 
 		margin_right = (term->cols - 1 - col) * CELL_WIDTH;
 
 		/* target cell */
-		cellp = &term->cells[line * term->cols + col];
+		cellp = &term->cells[line][col];
 
 		/* draw sixel pixmap */
 		if (cellp->has_pixmap) {

--- a/terminal.h
+++ b/terminal.h
@@ -3,7 +3,7 @@ void erase_cell(struct terminal_t *term, int y, int x)
 {
 	struct cell_t *cellp;
 
-	cellp             = &term->cells[y * term->cols + x];
+	cellp             = &term->cells[y][x];
 	cellp->glyphp     = term->glyph[DEFAULT_CHAR];
 	cellp->color_pair = term->color_pair; /* bce */
 	cellp->attribute  = ATTR_RESET;
@@ -17,8 +17,8 @@ void copy_cell(struct terminal_t *term, int dst_y, int dst_x, int src_y, int src
 {
 	struct cell_t *dst, *src;
 
-	dst = &term->cells[dst_y * term->cols + dst_x];
-	src = &term->cells[src_y * term->cols + src_x];
+	dst = &term->cells[dst_y][dst_x];
+	src = &term->cells[src_y][src_x];
 
 	if (src->width == NEXT_TO_WIDE) {
 		return;
@@ -56,12 +56,12 @@ int set_cell(struct terminal_t *term, int y, int x, const struct glyph_t *glyphp
 	cell.width      = glyphp->width;
 	cell.has_pixmap = false;
 
-	cellp    = &term->cells[y * term->cols + x];
+	cellp    = &term->cells[y][x];
 	*cellp   = cell;
 	term->line_dirty[y] = true;
 
 	if (cell.width == WIDE && x + 1 < term->cols) {
-		cellp        = &term->cells[y * term->cols + (x + 1)];
+		cellp        = &term->cells[y][x + 1];
 		*cellp       = cell;
 		cellp->width = NEXT_TO_WIDE;
 		return WIDE;
@@ -69,10 +69,18 @@ int set_cell(struct terminal_t *term, int y, int x, const struct glyph_t *glyphp
 	return HALF;
 }
 
+void swap_lines(struct terminal_t *term, int i, int j)
+{
+	struct cell_t *tmp;
+
+	tmp		= term->cells[i];
+	term->cells[i]	= term->cells[j];
+	term->cells[j]	= tmp;
+}
+
 void scroll(struct terminal_t *term, int from, int to, int offset)
 {
-	int size, abs_offset;
-	struct cell_t *dst, *src;
+	int abs_offset, scroll_lines;
 
 	if (offset == 0 || from >= to)
 		return;
@@ -83,19 +91,18 @@ void scroll(struct terminal_t *term, int from, int to, int offset)
 		term->line_dirty[y] = true;
 
 	abs_offset = abs(offset);
-	size = sizeof(struct cell_t) * ((to - from + 1) - abs_offset) * term->cols;
-
-	dst = term->cells + from * term->cols;
-	src = term->cells + (from + abs_offset) * term->cols;
+	scroll_lines = (to - from + 1) - abs_offset;
 
 	if (offset > 0) { /* scroll down */
-		memmove(dst, src, size);
+		for (int y = from; y < from + scroll_lines; y++)
+			swap_lines(term, y, y + offset);
 		for (int y = (to - offset + 1); y <= to; y++)
 			for (int x = 0; x < term->cols; x++)
 				erase_cell(term, y, x);
 	}
 	else {            /* scroll up */
-		memmove(src, dst, size);
+		for (int y = to; y >= from + abs_offset; y--)
+			swap_lines(term, y, y - abs_offset);
 		for (int y = from; y < from + abs_offset; y++)
 			for (int x = 0; x < term->cols; x++)
 				erase_cell(term, y, x);
@@ -347,7 +354,9 @@ bool term_init(struct terminal_t *term, int width, int height)
 	/* allocate memory */
 	term->line_dirty   = (bool *) ecalloc(term->lines, sizeof(bool));
 	term->tabstop      = (bool *) ecalloc(term->cols, sizeof(bool));
-	term->cells        = (struct cell_t *) ecalloc(term->lines * term->cols, sizeof(struct cell_t));
+	term->cells      = (struct cell_t **) ecalloc(term->lines, sizeof(struct cell_t *));
+	for (int i = 0; i < term->lines; i++)
+		term->cells[i] = (struct cell_t *) ecalloc(term->cols, sizeof(struct cell_t));
 	term->esc.buf      = (char *) ecalloc(1, term->esc.size);
 	term->sixel.pixmap = (uint8_t *) ecalloc(width * height, BYTES_PER_PIXEL);
 

--- a/yaft.h
+++ b/yaft.h
@@ -146,7 +146,7 @@ struct terminal_t {
 	int fd;                                  /* master of pseudo terminal */
 	int width, height;                       /* terminal size (pixel) */
 	int cols, lines;                         /* terminal size (cell) */
-	struct cell_t *cells;                    /* pointer to each cell: cells[y * lines + x] */
+	struct cell_t **cells;                    /* pointer to each cell: cells[y * lines + x] */
 	struct margin_t scroll;                    /* scroll margin */
 	struct point_t cursor;                   /* cursor pos (x, y) */
 	bool *line_dirty;                        /* dirty flag */


### PR DESCRIPTION
When you run a program with lots of line feed characters in its output (like `$ seq 10000`), yaft's input buffer gets quickly filled up.  Yaft then stops refreshing the screen (due to `LAZY_DRAW`) and has the appearance of being frozen.  Hitting `^C` promptly terminates the program, but then you will have to wait for several seconds to see the effect.

Profiling yaft, I found that calls to `memmove` for moving lines were the most time-consuming part.  This pull request modifies the scrolling operation so that lines are moved not by copying chunks of memory
but by pointer swaps, reducing the cost and making yaft more responsive while scrolling. 

Hope this helps.