### PR TITLE
Support 24bit color escape sequences

### DIFF
--- a/ctrlseq/csi.h
+++ b/ctrlseq/csi.h
@@ -249,6 +249,12 @@ void set_attr(struct terminal_t *term, struct parm_t *parm)
 			if ((i + 2) < parm->argc && dec2num(parm->argv[i + 1]) == 5) {
 				term->color_pair.fg = dec2num(parm->argv[i + 2]);
 				i += 2;
+			} else if ((i + 4) < parm->argc && dec2num(parm->argv[i + 1]) == 2) {
+				term->color_pair.fg = RGB_FLAG;
+				term->color_pair.fg |= dec2num(parm->argv[i + 2]) << 16;
+				term->color_pair.fg |= dec2num(parm->argv[i + 3]) << 8;
+				term->color_pair.fg |= dec2num(parm->argv[i + 4]);
+				i += 4;
 			}
 		} else if (num == 39) {                /* reset foreground */
 			term->color_pair.fg = DEFAULT_FG;
@@ -258,6 +264,12 @@ void set_attr(struct terminal_t *term, struct parm_t *parm)
 			if ((i + 2) < parm->argc && dec2num(parm->argv[i + 1]) == 5) {
 				term->color_pair.bg = dec2num(parm->argv[i + 2]);
 				i += 2;
+			} else if ((i + 4) < parm->argc && dec2num(parm->argv[i + 1]) == 2) {
+				term->color_pair.bg = RGB_FLAG;
+				term->color_pair.bg |= dec2num(parm->argv[i + 2]) << 16;
+				term->color_pair.bg |= dec2num(parm->argv[i + 3]) << 8;
+				term->color_pair.bg |= dec2num(parm->argv[i + 4]);
+				i += 4;
 			}
 		} else if (num == 49) {                /* reset background */
 			term->color_pair.bg = DEFAULT_BG;

--- a/ctrlseq/dcs.h
+++ b/ctrlseq/dcs.h
@@ -335,7 +335,8 @@ void reset_sixel(struct sixel_canvas_t *sc, struct color_pair_t color_pair, int 
 	sc->color_table[7] = color_list[7]; sc->color_table[15] = color_list[15];
 	*/
 	/* change palette 0, because its often the same color as terminal background */
-	sc->color_table[0] = color_list[color_pair.fg];
+	if (color_pair.fg < 0x100)
+		sc->color_table[0] = color_list[color_pair.fg];
 
 	/* 16 - 255: use xterm 256 color palette */
 	/* copy 256 color map */

--- a/fb/common.h
+++ b/fb/common.h
@@ -430,10 +430,15 @@ static inline void draw_line(struct framebuffer_t *fb, struct terminal_t *term, 
 					+ (line * CELL_HEIGHT + h) * fb->info.line_length;
 
 				/* set color palette */
-				if (cellp->glyphp->bitmap[h] & (0x01 << (bdf_padding + w)))
-					pixel = fb->real_palette[color_pair.fg];
-				else if (fb->wall && color_pair.bg == DEFAULT_BG) /* wallpaper */
+				if (cellp->glyphp->bitmap[h] & (0x01 << (bdf_padding + w))) {
+					if (color_pair.fg & RGB_FLAG)
+						pixel = color2pixel(&fb->info, color_pair.fg & 0xffffff);
+					else
+						pixel = fb->real_palette[color_pair.fg];
+				} else if (fb->wall && color_pair.bg == DEFAULT_BG) /* wallpaper */
 					memcpy(&pixel, fb->wall + pos, fb->info.bytes_per_pixel);
+				else if (color_pair.bg & RGB_FLAG)
+					pixel = color2pixel(&fb->info, color_pair.bg & 0xffffff);
 				else
 					pixel = fb->real_palette[color_pair.bg];
 

--- a/info/yaft.src
+++ b/info/yaft.src
@@ -1,5 +1,5 @@
 yaft-256color|yet another framebuffer terminal,
-	am, bce, msgr, xenl,
+	am, bce, msgr, xenl, ccc,
 
 	cols#80, lines#24, it#8, colors#256, pairs#32767,
 
@@ -60,3 +60,5 @@ yaft-256color|yet another framebuffer terminal,
 	kmous=\E[M, knp=\E[6~, kpp=\E[5~, kspd=^Z,
 
 	u6=\E[%i%d;%dR, u7=\E[6n,
+
+	initc=\E]4;%p1%d;rgb\:%p2%{255}%*%{1000}%/%2.2X/%p3%{255}%*%{1000}%/%2.2X/%p4%{255}%*%{1000}%/%2.2X\E\\,

--- a/terminal.h
+++ b/terminal.h
@@ -37,7 +37,7 @@ void copy_cell(struct terminal_t *term, int dst_y, int dst_x, int src_y, int src
 int set_cell(struct terminal_t *term, int y, int x, const struct glyph_t *glyphp)
 {
 	struct cell_t cell, *cellp;
-	uint8_t color_tmp;
+	uint32_t color_tmp;
 
 	cell.glyphp = glyphp;
 

--- a/x/x.h
+++ b/x/x.h
@@ -366,9 +366,15 @@ static inline void draw_line(struct xwindow_t *xw, struct terminal_t *term, int 
 			for (w = 0; w < CELL_WIDTH; w++) {
 				/* set color palette */
 				if (glyphp->bitmap[h] & (0x01 << (bdf_padding + w)))
-					XSetForeground(xw->display, xw->gc, color_list[color_pair.fg]);
+					if (color_pair.fg & RGB_FLAG)
+						XSetForeground(xw->display, xw->gc, color_pair.fg & 0xffffff);
+					else
+						XSetForeground(xw->display, xw->gc, color_list[color_pair.fg]);
 				else if (color_pair.bg != DEFAULT_BG)
-					XSetForeground(xw->display, xw->gc, color_list[color_pair.bg]);
+					if (color_pair.bg & RGB_FLAG)
+						XSetForeground(xw->display, xw->gc, color_pair.bg & 0xffffff);
+					else
+						XSetForeground(xw->display, xw->gc, color_list[color_pair.bg]);
 				else /* already draw */
 					continue;
 

--- a/yaft.h
+++ b/yaft.h
@@ -51,6 +51,7 @@ enum misc {
 	DEFAULT_CHAR       = SPACE,            /* used for erase char */
 	BRIGHT_INC         = 8,                /* value used for brightening color */
 	OSC_GWREPT         = 8900,             /* OSC Ps: mode number of yaft GWREPT */
+	RGB_FLAG           = 0x10000000,       /* identify RGB colors vs 256 colors */
 };
 
 enum char_attr {
@@ -101,7 +102,7 @@ enum glyph_width_t {
 
 struct margin_t { uint16_t top, bottom; };
 struct point_t { uint16_t x, y; };
-struct color_pair_t { uint8_t fg, bg; };
+struct color_pair_t { uint32_t fg, bg; };
 
 struct cell_t {
 	const struct glyph_t *glyphp;   /* pointer to glyph */


### PR DESCRIPTION
This actually seems to address #12.  I have tested this on a Linux 32-bit framebuffer, (I don't have anything else at my disposal).