### PR TITLE
Makefile fixes

### DIFF
--- a/makefile
+++ b/makefile
@@ -12,7 +12,7 @@ HDR = glyph.h yaft.h conf.h color.h parse.h terminal.h util.h \
 	fb/common.h fb/linux.h fb/freebsd.h fb/netbsd.h fb/openbsd.h \
 	x/x.h
 
-prefix ?= $(DESTDIR)/usr
+prefix ?= $(DESTDIR)/usr/local
 mandir ?= $(prefix)/share/man
 
 all: yaft
@@ -24,12 +24,15 @@ yaftx: mkfont_bdf
 mkfont_bdf: tools/mkfont_bdf.c tools/mkfont_bdf.h tools/bdf.h tools/util.h
 	$(CC) -o $@ $< $(CFLAGS) $(LDFLAGS)
 
+
+# This makefile creates a default glyph.h, if you haven't created one using ./glyphbuilder.sh.
 glyph.h: mkfont_bdf
-	# If you want to use your favorite fonts, please change following line
-	# usage: mkfont_bdf ALIAS BDF1 BDF2 BDF3... > glyph.h
+	# If you want to use your favorite fonts, please run ./glyphbuilder.sh.
+	# Or, you can change the following line and delete glyph.h.
+	# USAGE: mkfont_bdf ALIAS BDF1 BDF2 BDF3... > glyph.h
 	# ALIAS: glyph substitution rule file (see table/alias for more detail)
 	# BDF1 BDF2 BDF3...: monospace bdf files (must be the same size)
-	# If there is more than one glyph of the same codepoint, the glyph included in the first bdf file is choosed
+	# If there is more than one glyph of the same codepoint, the glyph included in the first bdf file is choosen.
 	./mkfont_bdf table/alias fonts/milkjf/milkjf_k16.bdf fonts/milkjf/milkjf_8x16r.bdf fonts/milkjf/milkjf_8x16.bdf fonts/terminus/ter-u16n.bdf > glyph.h
 
 yaft: yaft.c $(HDR)

--- a/makefile
+++ b/makefile
@@ -12,9 +12,8 @@ HDR = glyph.h yaft.h conf.h color.h parse.h terminal.h util.h \
 	fb/common.h fb/linux.h fb/freebsd.h fb/netbsd.h fb/openbsd.h \
 	x/x.h
 
-DESTDIR   =
-PREFIX    = $(DESTDIR)/usr
-MANPREFIX = $(DESTDIR)/usr/share/man
+prefix ?= $(DESTDIR)/usr
+mandir ?= $(prefix)/share/man
 
 all: yaft
 
@@ -42,26 +41,26 @@ yaftx: x/yaftx.c $(HDR)
 	$(CC) -o $@ $< $(XCFLAGS) $(XLDFLAGS)
 
 install:
-	mkdir -p $(PREFIX)/share/terminfo
-	tic -o $(PREFIX)/share/terminfo info/yaft.src
-	mkdir -p $(PREFIX)/bin/
-	install -m755 ./yaft $(PREFIX)/bin/yaft
-	install -m755 ./yaft_wall $(PREFIX)/bin/yaft_wall
-	mkdir -p $(MANPREFIX)/man1/
-	install -m644 ./man/yaft.1 $(MANPREFIX)/man1/yaft.1
+	mkdir -p $(prefix)/share/terminfo
+	tic -o $(prefix)/share/terminfo info/yaft.src
+	mkdir -p $(prefix)/bin/
+	install -m755 ./yaft $(prefix)/bin/yaft
+	install -m755 ./yaft_wall $(prefix)/bin/yaft_wall
+	mkdir -p $(mandir)/man1/
+	install -m644 ./man/yaft.1 $(mandir)/man1/yaft.1
 
 installx:
-	mkdir -p $(PREFIX)/share/terminfo
-	tic -o $(PREFIX)/share/terminfo info/yaft.src
-	mkdir -p $(PREFIX)/bin/
-	install -m755 ./yaftx $(PREFIX)/bin/yaftx
+	mkdir -p $(prefix)/share/terminfo
+	tic -o $(prefix)/share/terminfo info/yaft.src
+	mkdir -p $(prefix)/bin/
+	install -m755 ./yaftx $(prefix)/bin/yaftx
 
 uninstall:
-	rm -f $(PREFIX)/bin/yaft
-	rm -f $(PREFIX)/bin/yaft_wall
+	rm -f $(prefix)/bin/yaft
+	rm -f $(prefix)/bin/yaft_wall
 
 uninstallx:
-	rm -f $(PREFIX)/bin/yaftx
+	rm -f $(prefix)/bin/yaftx
 
 clean:
 	rm -f yaft yaftx mkfont_bdf glyph.h


### PR DESCRIPTION
Use the variables DESTDIR and prefix in the standard way. Also, recommend that people try glyphbuilder.sh instead of telling people to edit the makefile to change how glyph.h is built. 